### PR TITLE
Set .ico files to be detected as binary

### DIFF
--- a/src/main/java/com/rjrudin/marklogic/modulesloader/xcc/DefaultDocumentFormatGetter.java
+++ b/src/main/java/com/rjrudin/marklogic/modulesloader/xcc/DefaultDocumentFormatGetter.java
@@ -18,7 +18,7 @@ public class DefaultDocumentFormatGetter implements DocumentFormatGetter {
             return DocumentFormat.JSON;
         } else if (name.endsWith(".swf") || name.endsWith(".jpeg") || name.endsWith(".jpg") || name.endsWith(".png")
                 || name.endsWith(".gif") || name.endsWith(".svg") || name.endsWith(".ttf") || name.endsWith(".eot")
-                || name.endsWith(".woff") || name.endsWith(".cur")) {
+                || name.endsWith(".woff") || name.endsWith(".cur") || name.endsWith(".ico")) {
             return DocumentFormat.BINARY;
         }
         return DocumentFormat.TEXT;


### PR DESCRIPTION
We are using ml-gradle, but one of our endpoints has a favicon.ico file. 

I have added .ico to the list of binary file types to allow this to be loaded correctly.