### PR TITLE
adding woff2 and otf as a default binary types

### DIFF
--- a/src/main/java/com/marklogic/client/modulesloader/xcc/DefaultDocumentFormatGetter.java
+++ b/src/main/java/com/marklogic/client/modulesloader/xcc/DefaultDocumentFormatGetter.java
@@ -14,7 +14,7 @@ import com.marklogic.xcc.DocumentFormat;
 public class DefaultDocumentFormatGetter implements DocumentFormatGetter, FormatGetter {
 
     public final static String[] DEFAULT_BINARY_EXTENSIONS = new String[] { ".swf", ".jpeg", ".jpg", ".png", ".gif",
-            ".svg", ".ttf", ".eot", ".woff", ".cur", ".ico" };
+            ".svg", ".ttf", ".eot", ".woff", ".woff2", ".otf", ".cur", ".ico" };
 
     private List<String> binaryExtensions = new ArrayList<String>();
 


### PR DESCRIPTION
@rjrudin I added woff2 and otf which are common font file types as default binary files.